### PR TITLE
Pin gopkg versions, add grpc gateway and swagger support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,11 @@
 FROM golang:1.7-alpine
 
+ADD bin /bin/
+ADD Gofile /
 # protoc: download source, build and install (required by protoc-gen-go)
-RUN apk --no-cache add --virtual .builddeps \
-        curl unzip autoconf automake make libtool g++ && \
-    apk --no-cache add libstdc++ git && \
-    git clone https://github.com/google/protobuf.git --branch v3.0.0 --depth 1 && \
-    cd protobuf && \
-    ./autogen.sh && \
-    ./configure && \
-    make -j 3 && \
-    make install && \
-    make clean && \
-    cd .. && rm -r protobuf && \
-    apk del .builddeps && \
-    rm -rf /var/cache/apk/*
+RUN install-protoc
 
-# Get the source from GitHub
-RUN go get google.golang.org/grpc
-
-# Install protoc-gen-go
-RUN go get github.com/golang/protobuf/protoc-gen-go
+WORKDIR /go/src
 
 WORKDIR /go/src
 ENTRYPOINT [ "protoc" ]

--- a/Gofile
+++ b/Gofile
@@ -1,0 +1,4 @@
+google.golang.org/grpc 3235584c703acd8af8ab25132618c987c5606b66
+github.com/golang/protobuf/protoc-gen-go 98fa357170587e470c5f27d3c3ea0947b71eb455
+github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway 84398b94e188ee336f307779b57b3aa91af7063c
+github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger 84398b94e188ee336f307779b57b3aa91af7063c

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [appcelerator/protoc](https://hub.docker.com/r/appcelerator/protoc/)
 
 Simplified Docker image for generating protocol buffer bindings with gRPC support. Based on Alpine with latest protocol buffer (proto3) and gRPC versions.
+Supports go, grpc-gateway and swagger
 
 Usage:
 

--- a/bin/go-getter
+++ b/bin/go-getter
@@ -1,0 +1,41 @@
+#!/bin/sh
+# Like 'go get' but with pinned package versions. https://github.com/joewalnes/go-getter
+set -e
+: ${GOPATH?"GOPATH not set"}
+: ${1?"Usage: $0 [path-to-go-deps]"}
+sed -e 's/#.*//' $1 | grep -v -e '^[[:space:]]*$' | while read PKG HASH; do
+  echo "$PKG ($HASH)"
+  DEST=$GOPATH/src/$PKG
+  go get -d -u $PKG || true
+  FOUND_VCS=0
+  while [[ "$DEST" != "$GOPATH/src" ]] && [[ -d $DEST ]]
+  do
+    cd $DEST
+    if [ -d "$DEST/.git" ]; then
+      FOUND_VCS=1
+      echo "git checkout -q $HASH"
+      git checkout -q $HASH || true
+      git submodule update --init || true
+      echo "done"
+      break
+    elif [ -d "$DEST/.hg" ]; then
+      FOUND_VCS=1
+      hg update -q -c $HASH
+      break
+    elif [ -d "$DEST/.bzr" ]; then
+      FOUND_VCS=1
+      bzr update -q -r $HASH
+      break
+    elif [ -d "$DEST/.svn" ]; then
+      FOUND_VCS=1
+      svn update -q -r $HASH
+      break
+    else
+      DEST="$(readlink -f $DEST/..)"
+    fi
+  done
+  if [ $FOUND_VCS -eq 0 ]; then
+    echo "WARNING: Unrecognized VCS system for the golang package $PKG"
+  fi
+  go install $PKG || true
+done

--- a/bin/install-protoc
+++ b/bin/install-protoc
@@ -1,0 +1,19 @@
+#!/bin/sh
+apk --no-cache add --virtual .builddeps curl unzip autoconf automake make libtool g++
+apk --no-cache add libstdc++ git && \
+git clone https://github.com/google/protobuf.git --branch v3.1.0 --depth 1
+cd protobuf
+git submodule update --init
+./autogen.sh
+./configure
+make -j 3
+make install
+make clean
+cd ..
+rm -r protobuf
+go-getter /Gofile
+apk del .builddeps
+rm -rf /var/cache/apk/*
+rm /bin/go-getter
+rm /bin/install-protoc
+ 

--- a/go-getter-license.txt
+++ b/go-getter-license.txt
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Joe Walnes
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
closes https://github.com/appcelerator/docker-protoc/issues

To test run with 
```
--go_out=Mgoogle/api/annotations.proto=github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis/google/api,plugins=grpc:/go/src/
--grpc-gateway_out=logtostderr=true:/go/src
--swagger_out=logtostderr=true:/go/src/
-I /go/src/
-I /go/src/github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis
```